### PR TITLE
Replace underscore.js with itemized lodash modules

### DIFF
--- a/externalized-config.js
+++ b/externalized-config.js
@@ -1,6 +1,9 @@
 var fs   = require( 'fs' ),
-	_    = require( 'underscore' ),
-	argv = require( 'optimist' ).argv;
+    argv = require( 'optimist' ).argv,
+    forEach = require( 'lodash.foreach' ),
+    isArray = require( 'lodash.isarray' ),
+    isString = require( 'lodash.isstring' ),
+    isUndefined  = require( 'lodash.isundefined' );
 
 
 var defaultOptions = {
@@ -19,10 +22,10 @@ var _loadConfig = function( name ) {
 	// console.log( "processing configuration for " + name );
 
 	function replaceAll( str, find, replace ) {
-		if ( _.isString( find ) )
+		if ( isString( find ) )
 			return str.replace( new RegExp( find, 'g' ), replace );
-		else if ( _.isArray( find ) ) {
-			_.each( find, function( it ) {
+		else if ( isArray( find ) ) {
+			forEach( find, function( it ) {
 				str = str.replace( new RegExp( it[0], 'g' ), it[1] );
 			});
 		}
@@ -34,7 +37,7 @@ var _loadConfig = function( name ) {
 
     // console.log( "env -> " + envName + "; " + envValue );
 
-	if ( _.isUndefined( envValue ) || envValue == "undefined" ) {
+	if ( isUndefined( envValue ) || envValue == "undefined" ) {
 
 		var dotValue = replaceAll( defaultOptions.dot, [ [ "{{appname}}", name.toLowerCase() ], [ "~", _getUserHome() ], [ "-", "_" ] ] );
 
@@ -43,13 +46,13 @@ var _loadConfig = function( name ) {
 		 	return _parse( dotValue );
 		}
 		else {
-			if ( _.isUndefined( argv.config ) ) {
-        dotValue = replaceAll( defaultOptions.local, [ [ "{{appname}}", name.toLowerCase() ] ] );  
+			if ( isUndefined( argv.config ) ) {
+        dotValue = replaceAll( defaultOptions.local, [ [ "{{appname}}", name.toLowerCase() ] ] );
 
-        if ( fs.existsSync( dotValue ) ) { 
+        if ( fs.existsSync( dotValue ) ) {
           console.log( "configuration file " + dotValue + " loaded" );
           return _parse( dotValue );
-        }  
+        }
 			}
 			else {
 				var argValue = replaceAll( argv.config, [ [ "{{appname}}", name.toLowerCase() ], [ "~", _getUserHome() ], [ "-", "_" ] ] );
@@ -59,11 +62,11 @@ var _loadConfig = function( name ) {
 		 			return _parse( argValue );
 				}
 				else {
-          dotValue = replaceAll( defaultOptions.local, [ [ "{{appname}}", name.toLowerCase() ] ] ); 
-          if ( fs.existsSync( dotValue ) ) { 
+          dotValue = replaceAll( defaultOptions.local, [ [ "{{appname}}", name.toLowerCase() ] ] );
+          if ( fs.existsSync( dotValue ) ) {
             console.log( "configuration file " + dotValue + " loaded" );
             return _parse( dotValue );
-          }   
+          }
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "externalized-config",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "keywords": [ "externalized", "config", "configuration" ],
   "repository" : {
     "type" : "git",
@@ -13,7 +13,11 @@
   },
   "main": "externalized-config.js",
   "dependencies": {
-    "underscore": "1.8.3",
+    "lodash.foreach": "4.5.0",
+    "lodash.isarray": "4.0.0",
+    "lodash.isfunction": "3.0.8",
+    "lodash.isstring": "4.0.1",
+    "lodash.isundefined": "3.0.1",
     "optimist": "0.6.1"
   },
   "devDependencies": {

--- a/test/externalized-config.spec.js
+++ b/test/externalized-config.spec.js
@@ -1,5 +1,6 @@
-var _      = require( "underscore" ),
-    fs     = require( "fs" ),
+var fs     = require( "fs" ),
+    isFunction = require( "lodash.isfunction" ),
+    isUndefined = require( "lodash.isundefined" ),
     expect = require( "chai" ).expect,
     module = require( "../externalized-config" ),
     home   = process.env[ ( process.platform == 'win32' ) ? 'USERPROFILE' : 'HOME' ];
@@ -10,8 +11,8 @@ describe( "externalized-config module tests", function() {
 
     var config = config = module();
 
-    expect( _.isFunction(  module ) ).to.be.true;
-    expect( _.isUndefined( config ) ).to.be.false;
+    expect( isFunction(  module ) ).to.be.true;
+    expect( isUndefined( config ) ).to.be.false;
 
   });
 
@@ -53,7 +54,7 @@ describe( "externalized-config module tests", function() {
     });
 
     fs.writeFileSync( fileName, JSON.stringify( testData ) );
-  	
+
     process.env[ "EXTERNALIZED_CONFIG_CONFIG" ] = undefined;
 
     var config = module();
@@ -67,11 +68,11 @@ describe( "externalized-config module tests", function() {
     var fileName = process.cwd() + "/externalized-config.json",
         testData = {
           "aaa": "zzzz"
-        }; 
+        };
 
     fs.unlinkSync( home + "/.config/externalized_config.json" );
 
-    fs.writeFileSync( fileName, JSON.stringify( testData ) ); 
+    fs.writeFileSync( fileName, JSON.stringify( testData ) );
 
     process.env[ "EXTERNALIZED_CONFIG_CONFIG" ] = undefined;
 
@@ -79,7 +80,6 @@ describe( "externalized-config module tests", function() {
 
     fs.unlinkSync( fileName );
 
-    expect( config.aaa ).to.equal( 'zzzz' ); 
+    expect( config.aaa ).to.equal( 'zzzz' );
   });
 });
-


### PR DESCRIPTION
Replace old underscore library version with current lodash. Additionally depend on specific lodash function modules instead of the full library in package.json and in the source code.
